### PR TITLE
fix the color of a vertical line on the Uno

### DIFF
--- a/pinout.sh
+++ b/pinout.sh
@@ -60,7 +60,7 @@ echo -e  $B" | "$G"[ ]"$W"A2     +---+           "$T"INT0"$G"/"$W"3"$G"[ ]~"$B"|
 echo -e  $B" | "$G"[ ]"$W"A3                     "$T"INT1"$G"/"$W"2"$G"[ ] "$B"|   "$P"."
 echo -e  $B" | "$G"[ ]"$W"A4"$G"/"$T"SDA"$W"  RST SCK MISO     "$T"TX>"$W"1"$G"[ ] "$B"|   "$P"."
 echo -e  $B" | "$G"[ ]"$W"A5"$G"/"$T"SCL"$G"  [ ] [ ] [ ]      "$T"RX<"$W"0"$G"[ ] "$B"|   "$P"D0"
-echo -e  $B" |            "$G"[ ] [ ] [ ]"$G"              |"
+echo -e  $B" |            "$G"[ ] [ ] [ ]"$G"              "$B"|"
 echo -e  $B" |  "$W"UNO_R3    "$C"GND "$W"MOSI "$R"5V"$B"  ____________/"
 echo -e  $B"  \_______________________/"
 }


### PR DESCRIPTION
Last `|' on the right was $G (green) instead of $B (bright blue).